### PR TITLE
feat: persist terminal ID and improve API auth

### DIFF
--- a/src/vesync/constants.ts
+++ b/src/vesync/constants.ts
@@ -1,8 +1,12 @@
+const APP_VERSION = '5.6.70';
+const CLIENT_TYPE = 'iOS';
+const USER_AGENT = `VeSync/${APP_VERSION} (${CLIENT_TYPE} 17; iPhone)`;
+
 export const VESYNC = {
   BASE_URL: 'https://smartapi.vesync.com',
-  APP_VERSION: '5.6.70',
-  CLIENT_TYPE: 'iOS',
-  USER_AGENT: 'VeSync/5.6.70 (iOS 17; iPhone)',
+  APP_VERSION,
+  CLIENT_TYPE,
+  USER_AGENT,
   COUNTRY_CODE: 'US',
   LOCALE: 'en',
   TIMEZONE: 'America/Chicago',


### PR DESCRIPTION
## Summary
- persist a stable terminalId and use md5 password hashing during login
- sync client fingerprint headers and update auth tokens after refresh
- add jittered backoff rate limiting for all API calls

## Testing
- `npm run lint`
- `npm run build`
- `timedatectl status` *(fails: System has not been booted with systemd)*

------
https://chatgpt.com/codex/tasks/task_e_68a4f5ea340883308e746d86077664ca