### PR TITLE
Fix VeSync login to use v1 endpoint

### DIFF
--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -285,23 +285,24 @@ export default class VeSync {
 
         const pwdHashed = crypto
           .createHash('md5')
-          .update(this.password)
+          .update(this.password, 'utf8')
           .digest('hex');
 
         const response = await this.requestWithRetry(() =>
           axios.post(
-            '/cloud/v2/user/login',
+            '/cloud/v1/user/login',
             {
-              email: this.email,
+              account: this.email,
               password: pwdHashed,
+              devToken: '',
+              userType: 1,
               method: 'login',
+              token: '',
+              traceId: Date.now(),
               appVersion: VESYNC.APP_VERSION,
               clientType: VESYNC.CLIENT_TYPE,
               timeZone: VESYNC.TIMEZONE,
-              countryCode: VESYNC.COUNTRY_CODE,
-              traceId: Date.now(),
-              terminalId: this.terminalId,
-              hashPassword: 'md5'
+              countryCode: VESYNC.COUNTRY_CODE
             },
             {
               ...this.AXIOS_OPTIONS,

--- a/src/scripts/test-login.ts
+++ b/src/scripts/test-login.ts
@@ -11,20 +11,23 @@ async function main() {
     process.exit(1);
   }
 
-  const pwdHashed = crypto.createHash('md5').update(password).digest('hex');
+  const pwdHashed = crypto.createHash('md5').update(password, 'utf8').digest('hex');
 
   try {
     const { data } = await axios.post(
-      `${VESYNC.BASE_URL}/cloud/v2/user/login`,
+      `${VESYNC.BASE_URL}/cloud/v1/user/login`,
       {
-        email,
+        account: email,
         password: pwdHashed,
+        devToken: '',
+        userType: 1,
         method: 'login',
+        token: '',
+        traceId: Date.now(),
         appVersion: VESYNC.APP_VERSION,
         clientType: VESYNC.CLIENT_TYPE,
         timeZone: VESYNC.TIMEZONE,
-        countryCode: VESYNC.COUNTRY_CODE,
-        traceId: Date.now()
+        countryCode: VESYNC.COUNTRY_CODE
       },
       {
         headers: {


### PR DESCRIPTION
## Summary
- revert login to `/cloud/v1/user/login` and supply legacy fields
- hash password with MD5 and send as `account` field
- update test-login script to exercise new login flow

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`
- `npx ts-node src/scripts/test-login.ts` *(login failed Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68a4fbb0cbc08330914e3d2c87c99489