### PR TITLE
Fix Vesync login request payload

### DIFF
--- a/src/scripts/test-login.ts
+++ b/src/scripts/test-login.ts
@@ -1,6 +1,15 @@
 import axios from 'axios';
 import crypto from 'crypto';
+import { existsSync, readFileSync, writeFileSync } from 'fs';
 import { VESYNC } from '../vesync/constants';
+
+function getOrCreateTerminalId() {
+  const p = '/workspace/.vesync-terminal-id';
+  if (existsSync(p)) return readFileSync(p, 'utf8').trim();
+  const id = crypto.randomUUID();
+  writeFileSync(p, id);
+  return id;
+}
 
 async function main() {
   const email = process.env.VESYNC_EMAIL;
@@ -12,41 +21,43 @@ async function main() {
   }
 
   const pwdHashed = crypto.createHash('md5').update(password, 'utf8').digest('hex');
+  const terminalId = getOrCreateTerminalId();
 
   try {
-    const { data } = await axios.post(
-      '/cloud/v1/user/login',
-      {
-        method: 'login',
-        email,
-        password: pwdHashed,
-        devToken: '',
-        userType: 1,
-        token: '',
-        traceId: Date.now(),
-        appVersion: VESYNC.APP_VERSION,
-        clientType: VESYNC.CLIENT_TYPE,
-        timeZone: VESYNC.TIMEZONE,
-        countryCode: VESYNC.COUNTRY_CODE
-      },
-      {
-        baseURL: VESYNC.BASE_URL,
-        headers: {
-          'Content-Type': 'application/json',
-          'Accept-Language': VESYNC.LOCALE,
-          'User-Agent': VESYNC.USER_AGENT
-        }
-      }
-    );
+    const body = {
+      method: 'login',
+      account: email,
+      password: pwdHashed,
+      devToken: '',
+      userType: 1,
+      token: '',
+      traceId: Date.now(),
+      appVersion: VESYNC.APP_VERSION,
+      clientType: VESYNC.CLIENT_TYPE,
+      timeZone: VESYNC.TIMEZONE,
+      countryCode: VESYNC.COUNTRY_CODE,
+      terminalId
+    };
+    const headers = {
+      'Content-Type': 'application/json',
+      'Accept-Language': VESYNC.LOCALE,
+      'User-Agent': VESYNC.USER_AGENT
+    };
+
+    console.log('LOGIN url:', `${VESYNC.BASE_URL}/cloud/v1/user/login`);
+    console.log('LOGIN headers:', headers);
+    console.log('LOGIN body:', { ...body, password: '<md5>' });
+
+    const { data } = await axios.post('/cloud/v1/user/login', body, {
+      baseURL: VESYNC.BASE_URL,
+      headers
+    });
 
     console.log('code:', data.code, 'token:', data.result?.token);
   } catch (error: any) {
-    console.error(
-      'login failed',
-      'status:', error?.response?.status,
-      'code:', error?.response?.data?.code,
-      'msg:', error?.response?.data?.msg
-    );
+    console.error('login failed');
+    console.error('status:', error?.response?.status);
+    console.error('data:', error?.response?.data);
   }
 }
 

--- a/src/vesync/constants.ts
+++ b/src/vesync/constants.ts
@@ -1,6 +1,6 @@
 const APP_VERSION = '5.6.70';
-const CLIENT_TYPE = 'iOS';
-const USER_AGENT = `VeSync/${APP_VERSION} (${CLIENT_TYPE} 17; iPhone)`;
+const CLIENT_TYPE = 'Android';
+const USER_AGENT = `VeSync/${APP_VERSION} (Android 14; Pixel 7)`;
 
 export const VESYNC = {
   BASE_URL: 'https://smartapi.vesync.com',


### PR DESCRIPTION
## Summary
- send `account` field and terminal id in login request
- switch Vesync client fingerprint to Android and add debug logging
- update login test script with persistent terminal id and request dumps

## Testing
- `npm run lint`
- `npm run build`
- `node dist/scripts/test-login.js` *(fails: 400 Bad Request)*

------
https://chatgpt.com/codex/tasks/task_e_68a50224eeec8330adf994c51feec577