### PR TITLE
Harden VeSync login and add smoke tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,3 +145,14 @@ After that to start the local server use
 ```
 yarn watch
 ```
+
+### Testing
+
+Set `VESYNC_EMAIL` and `VESYNC_PASSWORD` before running the smoke tests:
+
+```
+VESYNC_EMAIL=you@example.com VESYNC_PASSWORD=yourpassword npm run test:login
+VESYNC_EMAIL=you@example.com VESYNC_PASSWORD=yourpassword npm run test:devices
+```
+
+The scripts disable proxies via `proxy: false`; if you have `HTTP_PROXY` or `HTTPS_PROXY` set, unset them to avoid 400 errors.

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "displayName": "Levoit Air Purifier",
   "main": "dist/index.js",
   "license": "Apache-2.0",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "private": false,
   "bugs": {
     "url": "https://github.com/RaresAil/homebridge-levoit-air-purifier/issues"
@@ -22,8 +22,10 @@
     "prepublishOnly": "npm run lint && npm run build",
     "watch": "npm run build && npm link && nodemon",
     "lint": "eslint src/**.ts --max-warnings=0",
-    "build": "rimraf ./dist && tsc",
-    "start": "npm run build && nodemon"
+    "build": "rimraf dist && tsc",
+    "start": "npm run build && nodemon",
+    "test:login": "node dist/scripts/test-login.js",
+    "test:devices": "node dist/scripts/test-devices.js"
   },
   "devDependencies": {
     "@types/async-lock": "^1.4.2",
@@ -40,7 +42,7 @@
   },
   "engines": {
     "homebridge": ">=1.3.5",
-    "node": ">=16"
+    "node": ">=18"
   },
   "dependencies": {
     "async-lock": "^1.4.1",

--- a/src/vesync/constants.ts
+++ b/src/vesync/constants.ts
@@ -1,13 +1,21 @@
 const APP_VERSION = '5.6.70';
-const CLIENT_TYPE = 'Android';
-const USER_AGENT = `VeSync/${APP_VERSION} (Android 14; Pixel 7)`;
+
+const ANDROID_FINGERPRINT = {
+  clientType: 'Android',
+  userAgent: `VeSync/${APP_VERSION} (Android 14; Pixel 7)`
+};
+
+const IOS_FINGERPRINT = {
+  clientType: 'iOS',
+  userAgent: `VeSync/${APP_VERSION} (iOS 17; iPhone)`
+};
 
 export const VESYNC = {
   BASE_URL: 'https://smartapi.vesync.com',
   APP_VERSION,
-  CLIENT_TYPE,
-  USER_AGENT,
   COUNTRY_CODE: 'US',
   LOCALE: 'en',
   TIMEZONE: 'America/Chicago',
+  ANDROID_FINGERPRINT,
+  IOS_FINGERPRINT
 };


### PR DESCRIPTION
## Summary
- implement shared axios client with md5 login payload, dual key fallback and iOS fingerprint retry
- improve error logging and log device region
- add login and device smoke test scripts
- add clean build step and bump to v4, bypass proxy in smoke tests, document test setup

## Testing
- `npm run build`
- `npm run lint`
- `VESYNC_EMAIL=test@example.com VESYNC_PASSWORD=bad npm run test:login` *(fails: Login failed status: unknown)*
- `VESYNC_EMAIL=test@example.com VESYNC_PASSWORD=bad npm run test:devices` *(fails: Device test failed status: unknown)*