### PR TITLE
Auto-build dist on install

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,6 +89,10 @@ The timers are not included because you can accomplish similar results by using 
 
 2. Discovers supported humidifiers (`Humidifiers`)
 
+### Requirements
+
+- Node.js 18 or newer
+
 ### Configuration
 
 - Via the Homebridge UI, enter the Homebridge VeSync Client plugin settings.
@@ -145,6 +149,8 @@ After that to start the local server use
 ```
 yarn watch
 ```
+
+If you clone this repository directly, run `npm install` and `npm run build` to generate the `dist` folder required by Homebridge. Installs from GitHub via npm will trigger the build automatically via the `prepare` script.
 
 ### Testing
 

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   "scripts": {
     "remove-link": "npm -g remove homebridge-levoit-air-purifier",
     "prepublishOnly": "npm run lint && npm run build",
+    "prepare": "npm run build",
     "watch": "npm run build && npm link && nodemon",
     "lint": "eslint src/**.ts --max-warnings=0",
     "build": "rimraf dist && tsc",


### PR DESCRIPTION
## Summary
- Auto-build the `dist` folder during `npm install` via a new `prepare` script
- Document Node.js 18+ requirement
- Explain build step when cloning the repo directly

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a51633e9508330844b317a00ed04d0