### PR TITLE
Add debug mode config flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can also do this directly via the homebridge config by adding your credentia
 
 ### Enabling Debug Mode
 
-In the config file, add `enableDebugMode: true`
+Enable verbose logging by setting `enableDebugMode: true` in the config. For backward compatibility, `debug: true` is also accepted.
 
 ```json
 {

--- a/config.schema.json
+++ b/config.schema.json
@@ -23,6 +23,13 @@
         "required": true,
         "description": "VeSync's account password"
       },
+      "enableDebugMode": {
+        "title": "Enable Debug Mode",
+        "type": "boolean",
+        "default": false,
+        "aliases": ["debug"],
+        "description": "Enable additional debug logging"
+      },
       "experimentalFeatures": {
         "title": "Experimental Features",
         "type": "array",


### PR DESCRIPTION
## Summary
- add `enableDebugMode` option with `debug` alias to config schema
- document debug flag in README

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52f8b46108330b8e9c7be8ad1a989