### PR TITLE
Log VeSync authentication failures and warn on session startup

### DIFF
--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -272,8 +272,12 @@ export default class VeSync {
   public async startSession(): Promise<boolean> {
     this.debugMode.debug('[START SESSION]', 'Starting auth session...');
     const firstLoginSuccess = await this.login();
+    if (!firstLoginSuccess) {
+      this.log.error('[START SESSION] Initial login failed');
+      return false;
+    }
     setInterval(this.login.bind(this), 1000 * 60 * 55);
-    return firstLoginSuccess;
+    return true;
   }
   private async login(): Promise<boolean> {
     return lock.acquire('api-call', async () => {
@@ -330,12 +334,14 @@ export default class VeSync {
 
         const { code, msg, result } = response.data;
         if (code !== 0) {
+          this.log.error(`[LOGIN] Failed with code ${code}, msg: ${msg}`);
           this.debugMode.debug('[LOGIN]', `Failed with code ${code}, msg: ${msg}`);
           return false;
         }
 
         const { token, accountID } = result ?? {};
         if (!token || !accountID) {
+          this.log.error('[LOGIN] Missing token or accountID in response');
           this.debugMode.debug('[LOGIN]', 'The authentication failed!! JSON:', JSON.stringify(response.data));
           return false;
         }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -122,6 +122,7 @@ export default class Platform implements DynamicPlatformPlugin {
       this.log.info('Connecting to the servers...');
       const successLogin = await this.client.startSession();
       if (!successLogin) {
+        this.log.warn('Failed to start session');
         return;
       }
 


### PR DESCRIPTION
## Summary
- log error when initial session login fails and when login responses have non-zero code or missing credentials
- warn during device discovery if starting a session fails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52f91ba8c8330b44d83ee43bc848a