### PR TITLE
feat: make client fingerprint configurable

### DIFF
--- a/config.schema.json
+++ b/config.schema.json
@@ -23,6 +23,21 @@
         "required": true,
         "description": "VeSync's account password"
       },
+      "appVersion": {
+        "title": "App Version",
+        "type": "string",
+        "default": "5.6.70"
+      },
+      "os": {
+        "title": "OS",
+        "type": "string",
+        "default": "Android 14; Pixel 7"
+      },
+      "clientType": {
+        "title": "Client Type",
+        "type": "string",
+        "default": "Android"
+      },
       "experimentalFeatures": {
         "title": "Experimental Features",
         "type": "array",

--- a/src/api/VeSync.ts
+++ b/src/api/VeSync.ts
@@ -9,7 +9,12 @@ import VeSyncHumidifier from './VeSyncHumidifier';
 import { VeSyncGeneric } from './VeSyncGeneric';
 import DebugMode from '../debugMode';
 import VeSyncFan from './VeSyncFan';
-import { VESYNC } from '../vesync/constants';
+import {
+  VESYNC,
+  DEFAULT_APP_VERSION,
+  DEFAULT_OS,
+  DEFAULT_CLIENT_TYPE
+} from '../vesync/constants';
 
 export enum BypassMethod {
   STATUS = 'getPurifierStatus',
@@ -43,21 +48,32 @@ export default class VeSync {
   private minuteStart = Date.now();
   private requestsThisMinute = 0;
   private readonly terminalId: string;
-  private clientType: string = VESYNC.ANDROID_FINGERPRINT.clientType;
+  private clientType: string;
+  private appVersion: string;
 
   constructor(
     private readonly email: string,
     private readonly password: string,
     public readonly debugMode: DebugMode,
-    public readonly log: Logger
+    public readonly log: Logger,
+    options?: { appVersion?: string; os?: string; clientType?: string }
   ) {
+    const {
+      appVersion = DEFAULT_APP_VERSION,
+      os = DEFAULT_OS,
+      clientType = DEFAULT_CLIENT_TYPE
+    } = options || {};
+
+    this.clientType = clientType;
+    this.appVersion = appVersion;
+
     this.api = axios.create({
       baseURL: VESYNC.BASE_URL,
       timeout: 30000,
       headers: {
         'Content-Type': 'application/json',
         'Accept-Language': VESYNC.LOCALE,
-        'User-Agent': VESYNC.ANDROID_FINGERPRINT.userAgent
+        'User-Agent': `VeSync/${appVersion} (${os})`
       }
     });
     this.terminalId = this.loadTerminalId();
@@ -99,7 +115,7 @@ export default class VeSync {
 
   private generateDetailBody() {
     return {
-      appVersion: VESYNC.APP_VERSION,
+      appVersion: this.appVersion,
       traceId: Date.now()
     };
   }

--- a/src/platform.ts
+++ b/src/platform.ts
@@ -42,6 +42,9 @@ export interface Config extends PlatformConfig {
   enableDebugMode?: boolean;
   password: string;
   email: string;
+  appVersion?: string;
+  os?: string;
+  clientType?: string;
 }
 
 export default class Platform implements DynamicPlatformPlugin {
@@ -61,7 +64,7 @@ export default class Platform implements DynamicPlatformPlugin {
     public readonly config: Config,
     public readonly api: API
   ) {
-    const { email, password, enableDebugMode } = this.config ?? {};
+    const { email, password, enableDebugMode, appVersion, os, clientType } = this.config ?? {};
     this.debugger = new DebugMode(!!enableDebugMode, this.log);
 
     try {
@@ -73,7 +76,11 @@ export default class Platform implements DynamicPlatformPlugin {
 
       this.debugger.debug('[PLATFORM]', 'Debug mode enabled');
 
-      this.client = new VeSync(email, password, this.debugger, log);
+      this.client = new VeSync(email, password, this.debugger, log, {
+        appVersion,
+        os,
+        clientType
+      });
 
       this.api.on('didFinishLaunching', () => {
         this.discoverDevices();

--- a/src/vesync/constants.ts
+++ b/src/vesync/constants.ts
@@ -1,18 +1,20 @@
-const APP_VERSION = '5.6.70';
+export const DEFAULT_APP_VERSION = '5.6.70';
+export const DEFAULT_OS = 'Android 14; Pixel 7';
+export const DEFAULT_CLIENT_TYPE = 'Android';
 
 const ANDROID_FINGERPRINT = {
-  clientType: 'Android',
-  userAgent: `VeSync/${APP_VERSION} (Android 14; Pixel 7)`
+  clientType: DEFAULT_CLIENT_TYPE,
+  userAgent: `VeSync/${DEFAULT_APP_VERSION} (${DEFAULT_OS})`
 };
 
 const IOS_FINGERPRINT = {
   clientType: 'iOS',
-  userAgent: `VeSync/${APP_VERSION} (iOS 17; iPhone)`
+  userAgent: `VeSync/${DEFAULT_APP_VERSION} (iOS 17; iPhone)`
 };
 
 export const VESYNC = {
   BASE_URL: 'https://smartapi.vesync.com',
-  APP_VERSION,
+  APP_VERSION: DEFAULT_APP_VERSION,
   COUNTRY_CODE: 'US',
   LOCALE: 'en',
   TIMEZONE: 'America/Chicago',


### PR DESCRIPTION
## Summary
- allow overriding appVersion, os, and clientType via plugin config
- VeSync client builds User-Agent and request bodies from supplied values
- expose defaults for appVersion, OS, and client type

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a52f93d16c833098678ab456c50c6c