### PR TITLE
Add debug mode toggle to configuration schema

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ You can also do this directly via the homebridge config by adding your credentia
 
 ### Enabling Debug Mode
 
-In the config file, add `enableDebugMode: true`
+Enable verbose logging from the Homebridge UI by toggling **Enable Debug Mode** in the plugin settings. This option maps to the `enableDebugMode` property in the config. You can also set it manually:
 
 ```json
 {

--- a/config.schema.json
+++ b/config.schema.json
@@ -38,6 +38,12 @@
         "type": "string",
         "default": "Android"
       },
+      "enableDebugMode": {
+        "title": "Enable Debug Mode",
+        "type": "boolean",
+        "default": false,
+        "description": "Enable verbose logging"
+      },
       "experimentalFeatures": {
         "title": "Experimental Features",
         "type": "array",


### PR DESCRIPTION
## Summary
- expose `enableDebugMode` as a boolean option in `config.schema.json`
- document enabling debug logging through Homebridge UI

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a60ba37ae08330b67592711579c082